### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Default value: `{}`
 Options to be set on the `marked` package, see https://github.com/chjj/marked for details. E.g.:
 
 ```
-marked: {
+markedOptions: {
   gfm: false
 }
 ```
@@ -157,7 +157,7 @@ grunt.initConfig({
       options: {
         layout: 'path/to/layout.html',
         basePath: 'path/to',
-        marked: {
+        markedOptions: {
           gfm: false,
           langPrefix: 'code-'
         }


### PR DESCRIPTION
The documentation for markedOptions was kind of missleading. Looked through your code and found that you're handing 'markedOptions' over to marked and not 'marked'.

'marked.setOptions(options.markedOptions);'
